### PR TITLE
PHP82-36: fix some PHP 8.2 deprecation exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.0",
         "guzzlehttp/streams": "~3.0",
         "react/promise": "~2.0"
     },

--- a/src/Client/CurlMultiHandler.php
+++ b/src/Client/CurlMultiHandler.php
@@ -25,6 +25,7 @@ class CurlMultiHandler
     private $handles = [];
     private $delays = [];
     private $maxHandles;
+    private $_mh;
 
     /**
      * This handler accepts the following options:

--- a/src/Future/FutureArray.php
+++ b/src/Future/FutureArray.php
@@ -33,7 +33,7 @@ class FutureArray implements FutureArrayInterface
         return count($this->_value);
     }
 
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->_value);
     }


### PR DESCRIPTION
Fix the following PHP 8.2 deprecation exceptions:
- `Exception: Errno: 8192, message: Creation of dynamic property GuzzleHttp\Ring\Client\CurlMultiHandler::$_mh is deprecated, file: /var/www/service/releases/3f3cde0dff9ef541f134412a752198a7770bb554/lib/guzzlehttp/ringphp/src/Client/CurlMultiHandler.php:47`
- `Exception: Errno: 8192, message: Return type of GuzzleHttp\Ring\Future\FutureArray::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice, file: /var/www/service/releases/3f3cde0dff9ef541f134412a752198a7770bb554/lib/guzzlehttp/ringphp/src/Future/FutureArray.php:36`

DataDog warning: https://app.datadoghq.com/apm/resource/rulesengineservice/web.request/32f787629f05b9ef?query=env%3Aproduction%20service%3Arulesengineservice%20operation_name%3Aweb.request&env=production&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=678609333822485882&spanViewType=errors&timeHint=1699911859290&topGraphs=latency%3Alatency%2Chits%3Aversion_count%2Cerrors%3Aversion_count%2CbreakdownAs%3Aavg_time&trace=AgAAAYvKpHxa-bKP1QAAAAAAAAAYAAAAAEFZdktwSkxBQUFBMVVxSldKeWRvMExKQgAAACQAAAAAMDE4YmNhYTQtYTA3Ni00ZjhiLThlZDUtN2Y2ZjJiZjUyODUz&traceID=4733886834300758384&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&view=spans&start=1700056436312&end=1700142836312&paused=false